### PR TITLE
Add overarching docker compose + notebooks setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Set these to the paths of each of the services' repositories
+CORE_SERVICE=../dj
+QUERY_SERVICE=../djqs
+MATERIALIZATION_SERVICE=../djms

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Summary
+
+<!-- What's this change about? -->
+
+### Test Plan
+
+<!-- How did you test your change? -->
+
+### Deployment Plan
+
+<!-- Any special instructions around deployment? -->

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,32 @@
+name: Run pre-commit hooks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-hooks:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@v3
+
+      - name: Set Up Python 🐍
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Install pre-commit 📦
+        run: |
+          pip install --upgrade pip
+          pip install --upgrade pre-commit
+      - name: Run pre-commit hooks ✅
+        run: pre-commit run --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,59 @@
+exclude: (^docs/|^clients/)
+
+repos:
+  # Autoformat: YAML, JSON, Markdown, etc.
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.6
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-ast
+        exclude: ^templates/
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-xml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: ["--fix=auto"] # replace 'auto' with 'lf' to enforce Linux/Mac line endings or 'crlf' for Windows
+
+  # Lint: Dockerfile
+  - repo: https://github.com/hadolint/hadolint.git
+    rev: v2.12.1-beta
+    hooks:
+      - id: hadolint-docker
+        entry: hadolint/hadolint:v2.12.1-beta hadolint
+
+  # Lint: YAML
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+        args: ["-d {extends: relaxed, rules: {line-length: disable}}", "-s"]
+        files: \.(yaml|yml)$
+
+  # Lint: Bash scripts
+  - repo: https://github.com/openstack-dev/bashate.git
+    rev: 2.1.1
+    hooks:
+      - id: bashate
+        args: ["--ignore=E006"]
+
+  # Strip output from Jupyter notebooks
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout
+
+  - repo: https://github.com/tomcatling/black-nb
+    rev: "0.7"
+    hooks:
+      - id: black-nb
+        files: '\.ipynb$'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # dj-demo
-Demo DJ app with all services
+
+To set up and run the demo:
+
+1. Check out the repositories for all DJ services:
+   - [DJ Core](https://github.com/DataJunction/dj): `git clone https://github.com/DataJunction/dj.git`
+   - [DJ Query Service](https://github.com/DataJunction/djqs): `git clone https://github.com/DataJunction/djqs.git`
+   - (optional) [DJ Materialization Service](https://github.com/DataJunction/djms): `git clone https://github.com/DataJunction/djms.git`
+2. Configure their locations in `.env`. The default setup assumes that they're in the immediate parent directory.
+3. Bring up all default services using `docker compose up`. This will also run a Jupyter Lab instance with access to the DJ services.
+4. To run the demo notebook, go to http://localhost:8888/lab/ and access it under `/notebooks/Modeling the Roads Example Database.ipynb`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,117 @@
+version: "3"
+volumes:
+  postgres_data: {}
+  postgres_roads_example: {}
+  redis_data: {}
+
+networks:
+  core:
+    driver: bridge
+  djqs-network:
+    driver: bridge
+
+services:
+  dj:
+    container_name: dj
+    stdin_open: true
+    tty: true
+    networks:
+      - core
+    environment:
+      - DOTENV_FILE=.docker-env/.env
+    build: "${CORE_SERVICE}"
+    volumes:
+      - "${CORE_SERVICE}:/code"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db_migration
+      - postgres_examples
+      - djqs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  db_migration:
+    container_name: db_migration
+    networks:
+      - core
+    environment:
+      - DOTENV_FILE=.docker-env/.env
+    build: "${CORE_SERVICE}"
+    volumes:
+      - "${CORE_SERVICE}:/code"
+    command: alembic upgrade head
+    restart: on-failure
+
+  postgres_examples:
+    container_name: postgres_examples
+    networks:
+      - core
+    image: postgres:latest
+    volumes:
+      - "${CORE_SERVICE}/examples/docker/postgres_init.sql:/docker-entrypoint-initdb.d/init.sql"
+      - postgres_data:/var/lib/postgresql/data
+      # dbt
+      - "${CORE_SERVICE}/examples/dbt/postgres_init.sql:/docker-entrypoint-initdb.d/init_dbt.sql"
+      - "${CORE_SERVICE}/examples/dbt:/docker-entrypoint-dbt"
+    environment:
+      - POSTGRES_PASSWORD=FoolishPassword
+      - POSTGRES_USER=username
+      - POSTGRES_DB=examples
+    ports:
+      - "5433:5432"
+
+  postgres-roads:
+    container_name: postgres-roads
+    networks:
+      - core
+    image: postgres:latest
+    volumes:
+      - "${CORE_SERVICE}/examples/docker/postgres_init.roads.sql:/docker-entrypoint-initdb.d/init.sql"
+      - "${CORE_SERVICE}/postgres_roads_example:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_PASSWORD=dj
+      - POSTGRES_USER=dj
+      - POSTGRES_DB=roads
+    ports:
+      - "5435:5432"
+
+  djqs:
+    container_name: djqs
+    stdin_open: true
+    tty: true
+    networks:
+      - core
+      - djqs-network
+    environment:
+      - DOTENV_FILE=.docker-env/.env
+    build: "${QUERY_SERVICE}"
+    volumes:
+      - "${QUERY_SERVICE}:/code"
+    ports:
+      - "8001:8001"
+    depends_on:
+      - djqs-db-migration
+      - postgres-roads
+
+  djqs-db-migration:
+    container_name: djqs-db-migration
+    networks:
+      - djqs-network
+    environment:
+      - DOTENV_FILE=.docker-env/.env
+    build: "${QUERY_SERVICE}"
+    volumes:
+      - "${QUERY_SERVICE}:/code"
+    command: alembic upgrade head
+    restart: on-failure
+
+  jupyter-notebook:
+    image: jupyter/minimal-notebook
+    container_name: jupyter
+    networks:
+      - core
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./notebooks:/home/jovyan/notebooks

--- a/notebooks/Modeling the Roads Example Database.ipynb
+++ b/notebooks/Modeling the Roads Example Database.ipynb
@@ -1,0 +1,1297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1e59e4df",
+   "metadata": {},
+   "source": [
+    "# Modeling the Roads Example Database"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0df819ea",
+   "metadata": {},
+   "source": [
+    "![dj-roads-erd](./images/dj-roads-erd.jpg)\n",
+    "*note: open in a new tab to see at full-resolution*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba3ff960",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "\n",
+    "DJ_PROTOCOL = \"http\"\n",
+    "DJ_HOST = \"localhost\"\n",
+    "DJ_PORT = 8000\n",
+    "DJ_URL = f\"{DJ_PROTOCOL}://{DJ_HOST}:{DJ_PORT}\"\n",
+    "\n",
+    "DJQS_URL = \"http://localhost:8001\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b9ee60b",
+   "metadata": {},
+   "source": [
+    "# Add a Catalog and an Engine\n",
+    "\n",
+    "In DJ, all nodes used in a query must share a common catalog. Before creating source nodes, add a `default` catalog and a spark engine to the system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da86a1ec",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(  # Add a catalog named public\n",
+    "    f\"{DJ_URL}/catalogs/\",\n",
+    "    json={\"name\": \"default\"},\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Add a catalog named public\n",
+    "    f\"{DJQS_URL}/catalogs/\",\n",
+    "    json={\"name\": \"default\"},\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Add postgres as an engine\n",
+    "    f\"{DJ_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://dj:dj@postgres-roads:5432/roads\",\n",
+    "    },\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Add postgres as an engine\n",
+    "    f\"{DJQS_URL}/engines/\",\n",
+    "    json={\n",
+    "        \"name\": \"postgres\",\n",
+    "        \"version\": \"\",\n",
+    "        \"uri\": \"postgresql://dj:dj@postgres-roads:5432/roads\",\n",
+    "    },\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Attach postgres engine to the public catalog\n",
+    "    f\"{DJ_URL}/catalogs/default/engines/\",\n",
+    "    json=[{\"name\": \"postgres\", \"version\": \"\"}],\n",
+    ")\n",
+    "print(response.json())\n",
+    "\n",
+    "response = requests.post(  # Attach postgres engine to the public catalog\n",
+    "    f\"{DJQS_URL}/catalogs/default/engines/\",\n",
+    "    json=[{\"name\": \"postgres\", \"version\": \"\"}],\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eebb213d",
+   "metadata": {},
+   "source": [
+    "# Create Source Nodes\n",
+    "Create twelve source nodes for each of the tables in the DJ roads example database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b6e7674",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"repair_order_id\": {\"type\": \"INT\"},\n",
+    "            \"municipality_id\": {\"type\": \"STR\"},\n",
+    "            \"hard_hat_id\": {\"type\": \"INT\"},\n",
+    "            \"order_date\": {\"type\": \"DATETIME\"},\n",
+    "            \"required_date\": {\"type\": \"DATETIME\"},\n",
+    "            \"dispatched_date\": {\"type\": \"DATETIME\"},\n",
+    "            \"dispatcher_id\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"description\": \"Repair orders\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"repair_orders\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"repair_orders\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99812125",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"repair_order_id\": {\"type\": \"INT\"},\n",
+    "            \"repair_type_id\": {\"type\": \"INT\"},\n",
+    "            \"price\": {\"type\": \"FLOAT\"},\n",
+    "            \"quantity\": {\"type\": \"INT\"},\n",
+    "            \"discount\": {\"type\": \"FLOAT\"},\n",
+    "        },\n",
+    "        \"description\": \"Details on repair orders\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"repair_order_details\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"repair_order_details\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "122440f9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"repair_type_id\": {\"type\": \"INT\"},\n",
+    "            \"repair_type_name\": {\"type\": \"STR\"},\n",
+    "            \"contractor_id\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"repair_type\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"repair_type\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4092b42",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"contractor_id\": {\"type\": \"INT\"},\n",
+    "            \"company_name\": {\"type\": \"STR\"},\n",
+    "            \"contact_name\": {\"type\": \"STR\"},\n",
+    "            \"contact_title\": {\"type\": \"STR\"},\n",
+    "            \"address\": {\"type\": \"STR\"},\n",
+    "            \"city\": {\"type\": \"STR\"},\n",
+    "            \"state\": {\"type\": \"STR\"},\n",
+    "            \"postal_code\": {\"type\": \"STR\"},\n",
+    "            \"country\": {\"type\": \"STR\"},\n",
+    "            \"phone\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"contractors\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"contractors\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05cc34e6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"municipality_id\": {\"type\": \"STR\"},\n",
+    "            \"municipality_type_id\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"municipality_municipality_type\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"municipality_municipality_type\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dc5d78b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"municipality_type_id\": {\"type\": \"STR\"},\n",
+    "            \"municipality_type_desc\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"municipality_type\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"municipality_type\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c20728c0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"municipality_id\": {\"type\": \"STR\"},\n",
+    "            \"contact_name\": {\"type\": \"STR\"},\n",
+    "            \"contact_title\": {\"type\": \"STR\"},\n",
+    "            \"local_region\": {\"type\": \"STR\"},\n",
+    "            \"phone\": {\"type\": \"STR\"},\n",
+    "            \"state_id\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"municipality\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"municipality\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b876fc24",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"dispatcher_id\": {\"type\": \"INT\"},\n",
+    "            \"company_name\": {\"type\": \"STR\"},\n",
+    "            \"phone\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"dispatchers\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"dispatchers\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cc47895",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"hard_hat_id\": {\"type\": \"INT\"},\n",
+    "            \"last_name\": {\"type\": \"STR\"},\n",
+    "            \"first_name\": {\"type\": \"STR\"},\n",
+    "            \"title\": {\"type\": \"STR\"},\n",
+    "            \"birth_date\": {\"type\": \"DATETIME\"},\n",
+    "            \"hire_date\": {\"type\": \"DATETIME\"},\n",
+    "            \"address\": {\"type\": \"STR\"},\n",
+    "            \"city\": {\"type\": \"STR\"},\n",
+    "            \"state\": {\"type\": \"STR\"},\n",
+    "            \"postal_code\": {\"type\": \"STR\"},\n",
+    "            \"country\": {\"type\": \"STR\"},\n",
+    "            \"manager\": {\"type\": \"INT\"},\n",
+    "            \"contractor_id\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"hard_hats\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"hard_hats\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87aeb9b6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"hard_hat_id\": {\"type\": \"INT\"},\n",
+    "            \"state_id\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"hard_hat_state\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"hard_hat_state\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "310c9ef4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"state_id\": {\"type\": \"INT\"},\n",
+    "            \"state_name\": {\"type\": \"STR\"},\n",
+    "            \"state_abbr\": {\"type\": \"STR\"},\n",
+    "            \"state_region\": {\"type\": \"INT\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"us_states\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"us_states\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7ce8d9d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/source/\",\n",
+    "    json={\n",
+    "        \"columns\": {\n",
+    "            \"us_region_id\": {\"type\": \"INT\"},\n",
+    "            \"us_region_description\": {\"type\": \"STR\"},\n",
+    "        },\n",
+    "        \"description\": \"Information on different types of repairs\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"us_region\",\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"us_region\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a1c79a5",
+   "metadata": {},
+   "source": [
+    "# Create Dimension Nodes\n",
+    "\n",
+    "Dimension nodes are how you represent dimensions in the data model and can be defined using any SQL, including filters as well as joins to source nodes, transform nodes, and other dimension nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dffcf40a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/transform/\",\n",
+    "    json={\n",
+    "        \"description\": \"Repair order dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            repair_order_id,\n",
+    "            municipality_id,\n",
+    "            hard_hat_id,\n",
+    "            dispatcher_id\n",
+    "            FROM repair_orders\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"repair_order_transform\",\n",
+    "        \"type\": \"transform\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41d414c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Repair order dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            repair_order_id,\n",
+    "            municipality_id,\n",
+    "            hard_hat_id,\n",
+    "            dispatcher_id\n",
+    "            FROM repair_orders\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"repair_order\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b61a229",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Contractor dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            contractor_id,\n",
+    "            company_name,\n",
+    "            contact_name,\n",
+    "            contact_title,\n",
+    "            address,\n",
+    "            city,\n",
+    "            state,\n",
+    "            postal_code,\n",
+    "            country,\n",
+    "            phone\n",
+    "            FROM contractors\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"contractor\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a866d4a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Hard hat dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            hard_hat_id,\n",
+    "            last_name,\n",
+    "            first_name,\n",
+    "            title,\n",
+    "            birth_date,\n",
+    "            hire_date,\n",
+    "            address,\n",
+    "            city,\n",
+    "            state,\n",
+    "            postal_code,\n",
+    "            country,\n",
+    "            manager,\n",
+    "            contractor_id\n",
+    "            FROM hard_hats\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"hard_hat\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d995d032",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Hard hat dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            hh.hard_hat_id,\n",
+    "            last_name,\n",
+    "            first_name,\n",
+    "            title,\n",
+    "            birth_date,\n",
+    "            hire_date,\n",
+    "            address,\n",
+    "            city,\n",
+    "            state,\n",
+    "            postal_code,\n",
+    "            country,\n",
+    "            manager,\n",
+    "            contractor_id,\n",
+    "            hhs.state_id AS state_id\n",
+    "            FROM hard_hats hh\n",
+    "            LEFT JOIN hard_hat_state hhs\n",
+    "            ON hh.hard_hat_id = hhs.hard_hat_id\n",
+    "            WHERE hh.state_id = 'NY'\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"local_hard_hats\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ebaa645",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"US state dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            state_id,\n",
+    "            state_name,\n",
+    "            state_abbr,\n",
+    "            state_region,\n",
+    "            r.us_region_description AS state_region_description\n",
+    "            FROM us_states s\n",
+    "            LEFT JOIN us_region r\n",
+    "            ON s.state_region = r.us_region_id\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"us_state\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2105f66",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Dispatcher dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            dispatcher_id,\n",
+    "            company_name,\n",
+    "            phone\n",
+    "            FROM dispatchers\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"dispatcher\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e5b3210",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/dimension/\",\n",
+    "    json={\n",
+    "        \"description\": \"Municipality dimension\",\n",
+    "        \"query\": \"\"\"\n",
+    "            SELECT\n",
+    "            m.municipality_id,\n",
+    "            contact_name,\n",
+    "            contact_title,\n",
+    "            local_region,\n",
+    "            phone,\n",
+    "            state_id,\n",
+    "            mmt.municipality_type_id,\n",
+    "            mt.municipality_type_desc\n",
+    "            FROM municipality AS m\n",
+    "            LEFT JOIN municipality_municipality_type AS mmt\n",
+    "            ON m.municipality_id = mmt.municipality_id\n",
+    "            LEFT JOIN municipality_type AS mt\n",
+    "            ON mmt.municipality_type_id = mt.municipality_type_desc\n",
+    "        \"\"\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"municipality_dim\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d405291d",
+   "metadata": {},
+   "source": [
+    "# Add Metrics\n",
+    "\n",
+    "Metrics are defined by writing a SQL query that performs an aggregation function on an expression using columns from any **single** source node, dimension node, or transform node. Here are some metrics that can be added to the DJ server.\n",
+    "\n",
+    "- `num_repair_orders` - Number of repair orders\n",
+    "- `avg_repair_price` - Avg price of a repair order\n",
+    "- `total_repair_cost` - Total price of a repair order\n",
+    "- `avg_length_of_employment` - Avg length of employment\n",
+    "- `total_repair_order_discounts` - Total discounts on repair orders\n",
+    "- `avg_repair_order_discounts` - Avg discount on repair orders\n",
+    "- `avg_time_to_dispatch` - Avg time to dispatch\n",
+    "- `avg_time_to_dispatch_local` - Avg time to dispatch in NYC\n",
+    "\n",
+    "Each of these metrics can be grouped by any dimensions that are discoverable through dimension labels, such as `municipality`, `state`, `region`, `contractor`, `dispatcher`, or `hard_hat`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f87bc290",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Number of repair orders\",\n",
+    "        \"query\": \"SELECT count(repair_order_id) as num_repair_orders FROM repair_orders\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"num_repair_orders\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be519eac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Average repair price\",\n",
+    "        \"query\": \"SELECT avg(price) as avg_repair_price FROM repair_order_details\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"avg_repair_price\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8d229c3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Total repair cost\",\n",
+    "        \"query\": \"SELECT sum(price) as total_repair_cost FROM repair_order_details\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"total_repair_cost\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebaa0482",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Average length of employment\",\n",
+    "        \"query\": \"SELECT avg(NOW() - hire_date) as avg_length_of_employment FROM hard_hats\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"avg_length_of_employment\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0144baf7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Total repair order discounts\",\n",
+    "        \"query\": \"SELECT sum(price * discount) as total_discount FROM repair_order_details\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"total_repair_order_discounts\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fce8e1f7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Total repair order discounts\",\n",
+    "        \"query\": \"SELECT avg(price * discount) as avg_repair_order_discount FROM repair_order_details\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"avg_repair_order_discounts\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cbba1585",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/metric/\",\n",
+    "    json={\n",
+    "        \"description\": \"Average time to dispatch a repair order\",\n",
+    "        \"query\": \"SELECT avg(dispatched_date - order_date) as avg_time_to_dispatch FROM repair_orders\",\n",
+    "        \"mode\": \"published\",\n",
+    "        \"name\": \"avg_time_to_dispatch\",\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2edbf18",
+   "metadata": {},
+   "source": [
+    "# Link Columns to Dimension Nodes\n",
+    "\n",
+    "Dimensions are discovered through labels on node columns throughout the DJ DAG. These labels link these columns to the primary key(s) of the dimension node. Create links to all columns in the DJ DAG to their corresponding dimension nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bf208cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_order_details/columns/repair_order_id/?dimension=repair_order&dimension_column=repair_order_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5fe02fe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/municipality_id/?dimension=municipality_dim&dimension_column=municipality_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5237f6f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_type/columns/contractor_id/?dimension=contractor&dimension_column=contractor_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3370384",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/hard_hat_id/?dimension=hard_hat&dimension_column=hard_hat_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb441b50",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/repair_orders/columns/dispatcher_id/?dimension=dispatcher&dimension_column=dispatcher_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab3ffde2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/nodes/local_hard_hats/columns/state_id/?dimension=us_state&dimension_column=state_id\"\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7c11045",
+   "metadata": {},
+   "source": [
+    "# View All Existing Nodes\n",
+    "\n",
+    "Let's look at the full list of nodes that are now in the DJ system and can be used to generate queries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3f61edb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "nodes = requests.get(f\"{DJ_URL}/nodes/\").json()\n",
+    "for i in sorted([f\"{node['type']} -> {node['name']}\" for node in nodes]):\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b94aede1",
+   "metadata": {},
+   "source": [
+    "# Generate SQL Using Metrics & Dimensions\n",
+    "\n",
+    "You can now generate SQL queries for any metric and include any of the discoverable dimensions that you'd like to group it by. Let's list out the dimensions that are available for each metric in DJ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccb90f88",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for metric in [\n",
+    "    \"avg_length_of_employment\",\n",
+    "    \"avg_repair_order_discounts\",\n",
+    "    \"avg_repair_price\",\n",
+    "    \"avg_time_to_dispatch\",\n",
+    "    \"num_repair_orders\",\n",
+    "    \"total_repair_cost\",\n",
+    "    \"total_repair_order_discounts\",\n",
+    "]:\n",
+    "    response = requests.get(\n",
+    "        f\"{DJ_URL}/metrics/{metric}/\",\n",
+    "    )\n",
+    "    metric_metadata = response.json()\n",
+    "    print(metric)\n",
+    "    print(\"---\")\n",
+    "    for dimension in metric_metadata[\"dimensions\"]:\n",
+    "        print(dimension)\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f949edf8",
+   "metadata": {},
+   "source": [
+    "### Using the metric SQL endpoint, let's generate some SQL for a few metrics, grouped by dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22f78085",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/sql/num_repair_orders/?dimensions=hard_hat.first_name,hard_hat.last_name\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "960b072c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/sql/total_repair_order_discounts/?dimensions=repair_order.hard_hat_id\",\n",
+    ")\n",
+    "print(response.json()[\"sql\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb60b48",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/sql/avg_time_to_dispatch/?dimensions=hard_hat.state\",\n",
+    ")\n",
+    "print(response.json()[\"sql\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8fea581",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/sql/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
+    ")\n",
+    "print(response.json()[\"sql\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d79622a",
+   "metadata": {},
+   "source": [
+    "# Report Materializations by Setting Availability on a Node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d65c0337",
+   "metadata": {},
+   "source": [
+    "Materializations can be reported by adding an `availability` to a node. When DJ builds the query, it will use any availability states it finds. Let's add an availability to the `repair_order` dimension node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0de9f612",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Add an availability for the contractor dimension node\n",
+    "response = requests.post(\n",
+    "    f\"{DJ_URL}/data/repair_order/availability/\",\n",
+    "    json={\n",
+    "        \"catalog\": \"default\",\n",
+    "        \"schema_\": \"roads\",\n",
+    "        \"table\": \"repair_order_materialization_123\",\n",
+    "        \"valid_through_ts\": 20230306,\n",
+    "        \"max_partition\": [\"20230305\"],\n",
+    "        \"min_partition\": [\"20230304\"],\n",
+    "    },\n",
+    ")\n",
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aae078e9",
+   "metadata": {},
+   "source": [
+    "### Now the same request that incldues the `repair_order` dimension will use the `availability` that it finds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c069f3ff",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/sql/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
+    ")\n",
+    "print(response.json()[\"sql\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d28d942-e41f-4da4-89d7-a6eb62d0d145",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/hard_hat/\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14a5d5ac-1417-4e59-9438-ddad3b2d4245",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/num_repair_orders/?dimensions=hard_hat.first_name,hard_hat.last_name\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27a03f70-66f7-4166-8883-95576f5e86be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/total_repair_order_discounts/?dimensions=repair_order.hard_hat_id\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f141414",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/avg_time_to_dispatch/?dimensions=hard_hat.state\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dafd0bf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(\n",
+    "    f\"{DJ_URL}/data/avg_repair_price/?dimensions=repair_order.municipality_id\",\n",
+    ")\n",
+    "print(response.json())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Summary

* Adds an overarching docker compose file that brings together all DJ services.
* Includes a container running Jupyter Lab, where the example notebooks can be viewed/run.
* Paths for each of the services can be set in `.env`. The default paths are set to the immediate parent dir.

### Test Plan

Ran `docker compose up`.
Ran through the example notebook.

### Deployment Plan

N/A