### PR TITLE
Add jaeger container for telemetry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - core
     environment:
       - DOTENV_FILE=.docker-env/.env
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=datajunction.server
     build: "${CORE_SERVICE}"
     volumes:
       - "${CORE_SERVICE}:/code"
@@ -44,6 +46,18 @@ services:
       - "${CORE_SERVICE}:/code"
     command: alembic upgrade head
     restart: on-failure
+
+  jaeger:
+    container_name: jaeger
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268:14268"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug
+    networks:
+      - core
 
   postgres_examples:
     container_name: postgres_examples


### PR DESCRIPTION
### Summary

This uses the recently added auto instrumentation of the opentelemetry protocol and adds a jaeger container to the docker compose setup.

![Screenshot 2023-04-12 at 1 31 31 PM](https://user-images.githubusercontent.com/43911210/231538257-f6e8fae7-4d4f-4db4-b7bb-9afeb23cad48.png)

### Test Plan

- Ran `docker compose up`
- navigated to [http://localhost:16686/](http://localhost:16686/)
- Ran the requests in the demo roads notebooks
- Confirmed that the traces are being collected and processed
### Deployment Plan

<!-- Any special instructions around deployment? -->
